### PR TITLE
Take the biggest face when multiple faces

### DIFF
--- a/app/webcam_application.py
+++ b/app/webcam_application.py
@@ -119,7 +119,7 @@ class WebcamApplication(QObject):
         self._f_ready = False
 
     def _get_landmarks(self, canvas: ColorImage, frame: ColorImage) -> NDArray[(68, 2), Int[32]]:
-        """Returns the numpy array with all elements in 0 if theres no face in the frame.
+        """Returns the numpy array with all elements in 0 if there's no face in the frame.
 
         Note that one can use .any() to check if any of the elements is not 0.
         """


### PR DESCRIPTION
## What's the problem?
The `WebcamApplication` object decides which face(landmark) should be processed on by all
applications: distance, posture, etc.
In the original design, there's a strict restriction that some applications are automatically disabled
when multiple-faces occurs. But it's common that the user be photobombed.

## What's better?
When a frame contains multiple faces, the face with biggest area is considered as the face
of the user, since he or she should be the closest.

Resolves: #8