### PR TITLE
Let user choose where to put the reference image

### DIFF
--- a/app/webcam_application_.py
+++ b/app/webcam_application_.py
@@ -313,7 +313,7 @@ class WebcamApplication(QObject):
         return landmarks
 
     def _update_ref_landmarks(self) -> None:
-        # Creates the DistanceCalculator with reference image.
+        """Updates the reference landmarks with the reference image path."""
         ref_img: ColorImage = cv2.imread(self._ref_img_path)
         faces: dlib.rectangles = self._face_detector(ref_img)
         if len(faces) != 1:

--- a/distance/calculator.py
+++ b/distance/calculator.py
@@ -17,7 +17,7 @@ class DistanceCalculator:
     def __init__(self, landmarks: NDArray[(68, 2), Int[32]], camera_dist: float) -> None:
         """
         Arguments:
-            landmarks: (x, y) coordinates of the 68 face landmarks.
+            landmarks: (x, y) coordinates of the 68 face landmarks in the reference image.
             camera_dist: Distance between face and camera when taking reference image.
         """
         self._product: float = self._get_face_width(landmarks) * camera_dist

--- a/distance/guard.py
+++ b/distance/guard.py
@@ -149,7 +149,7 @@ class DistanceGuard(QObject):
             state: The state of distance to send info about.
         """
         # TODO: Should too far but not too close be considered as distraction?
-        if self._grader is None:
+        if self._grader is not None:
             if state is DistanceState.NORMAL:
                 self._grader.add_body_concentration()
             else:

--- a/distance/guard.py
+++ b/distance/guard.py
@@ -53,12 +53,9 @@ class DistanceGuard(QObject):
         """
         super().__init__()
 
-        if calculator is not None:
-            self._calculator: DistanceCalculator = calculator
-        if warn_dist is not None:
-            self._warn_dist: float = warn_dist
-        if grader is not None:
-            self._grader: ConcentrationGrader = grader
+        self._calculator: Optional[DistanceCalculator] = calculator
+        self._warn_dist: Optional[float] = warn_dist
+        self._grader: Optional[ConcentrationGrader] = grader
         self._warning_enabled: bool = warning_enabled
 
         self._wavfile: str = to_abs_path("sounds/too_close.wav")
@@ -106,15 +103,15 @@ class DistanceGuard(QObject):
             s_distance_refreshed: With the distance calculated.
         """
         # Can't do any thing without DistanceCalculator.
-        if not hasattr(self, "_calculator"):
+        if self._calculator is None:
             return
         # Distance can be calculated when DistanceCalculator exists.
-        if hasattr(self, "_calculator"):
+        if self._calculator is not None:
             distance: float = self._calculator.calculate(landmarks)
             self._put_distance_text(canvas, distance)
         # Has DistanceCalculator but no warn dist.
         # Send the distance with normal state. And no further process.
-        if not hasattr(self, "_warn_dist"):
+        if self._warn_dist is None:
             self.s_distance_refreshed.emit(distance, DistanceState.NORMAL)
             return
 
@@ -152,7 +149,7 @@ class DistanceGuard(QObject):
             state: The state of distance to send info about.
         """
         # TODO: Should too far but not too close be considered as distraction?
-        if hasattr(self, "_grader"):
+        if self._grader is None:
             if state is DistanceState.NORMAL:
                 self._grader.add_body_concentration()
             else:

--- a/intergrated_gui/component.py
+++ b/intergrated_gui/component.py
@@ -3,7 +3,6 @@
 All with font "Arial".
 """
 
-
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QFont
 from PyQt5 import QtWidgets
@@ -11,19 +10,30 @@ from PyQt5 import QtWidgets
 from posture.train import PostureLabel
 
 
+class _ArialFont(QFont):
+    """A QFont class with the first argument of constructor be "Arial"."""
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__("Arial", *args, **kwargs)
+
+
 class ActionButton(QtWidgets.QPushButton):
     def __init__(self, text: str, font_size: int = 12) -> None:
         super().__init__(text)
-        self.setFont(QFont("Arial", font_size))
+        self.setFont(_ArialFont(font_size))
 
 
 class CaptureMessageBox(QtWidgets.QMessageBox):
-    def __init__(self, label: PostureLabel, number_of_images: int, parent: QtWidgets.QWidget = None) -> None:
+    """Displays the result of capturing the image of posture model."""
+    def __init__(
+            self,
+            label: PostureLabel,
+            number_of_images: int,
+            parent: QtWidgets.QWidget = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Finish")
         self.setIcon(QtWidgets.QMessageBox.Information)
         self.setText(f"You've captured {number_of_images} images of label '{label.name}.'")
-        self.setFont(QFont("Arial", 12))
+        self.setFont(_ArialFont(12))
 
 
 class CheckableGroupBox(QtWidgets.QGroupBox):
@@ -31,11 +41,13 @@ class CheckableGroupBox(QtWidgets.QGroupBox):
         super().__init__(title, parent)
         self.setCheckable(True)
         self.setChecked(False)
-        self.setFont(QFont("Arial", 12))
+        self.setFont(_ArialFont(12))
 
 
 class HorizontalSlider(QtWidgets.QSlider):
-    def __init__(self, min_val: int = 0, max_val: int = 100, cur_val: int = 30) -> None:
+    def __init__(self,
+                 min_val: int = 0,
+                 max_val: int = 100, cur_val: int = 30) -> None:
         super().__init__(Qt.Horizontal)
         self.setRange(min_val, max_val)
         self.setValue(cur_val)
@@ -49,12 +61,14 @@ class LCDClock(QtWidgets.QLCDNumber):
 
 
 class Label(QtWidgets.QLabel):
-    def __init__(self, text: str = "", font_size: int = 12, wrap: bool = False) -> None:
+    def __init__(self, text: str = "",
+                 font_size: int = 12, wrap: bool = False) -> None:
         super().__init__(text)
-        self.setFont(QFont("Arial", font_size))
+        self.setFont(_ArialFont(font_size))
         self.setWordWrap(wrap)
 
     def set_color(self, color: str) -> None:
+        """Sets the text color of the label."""
         self.setStyleSheet(f"color: {color};")
 
 
@@ -62,12 +76,13 @@ class LineEdit(QtWidgets.QLineEdit):
     """Placeholder text is easily set with constructor.
     Also provides simple color setting method.
     """
-    def __init__(self, text: str = "", font_size: int = 12) -> None:
+    def __init__(self, place_hold_text: str = "", font_size: int = 12) -> None:
         super().__init__()
-        self.setPlaceholderText(text)
-        self.setFont(QFont("Arial", font_size))
+        self.setPlaceholderText(place_hold_text)
+        self.setFont(_ArialFont(font_size))
 
     def set_color(self, color: str) -> None:
+        """Sets the text color of the line."""
         self.setStyleSheet(f"color: {color};")
 
 
@@ -82,27 +97,30 @@ class MessageLabel(Label):
     """MessageLabel is used to display warning or status.
     Also provides simple color setting method.
     """
-    def __init__(self, text: str = "", font_size: int = 10, color: str = "red") -> None:
+    def __init__(self, text: str = "",
+                 font_size: int = 10, color: str = "red") -> None:
         super().__init__(text, font_size)
         self.set_color(color)
 
     def set_color(self, color: str) -> None:
+        """Sets the color of the message text."""
         self.setStyleSheet(f"color: {color};")
 
 
 class OptionCheckBox(QtWidgets.QCheckBox):
     def __init__(self, text: str, font_size: int = 12) -> None:
         super().__init__(text)
-        self.setFont(QFont("Arial", font_size))
+        self.setFont(_ArialFont(font_size))
 
 
 class OptionRadioButton(QtWidgets.QRadioButton):
     def __init__(self, text: str, font_size: int = 12) -> None:
         super().__init__(text)
-        self.setFont(QFont("Arial", font_size))
+        self.setFont(_ArialFont(font_size))
 
 
 class ProgressDialog(QtWidgets.QProgressDialog):
+    """A modal to show the progress."""
     def __init__(self, maximum: int, parent: QtWidgets.QWidget = None) -> None:
         super().__init__(parent)
         # Block input to other windows.
@@ -112,7 +130,7 @@ class ProgressDialog(QtWidgets.QProgressDialog):
         self.setCancelButton(None)
         self.setMaximum(maximum)
         self.setFixedSize(300, 100)
-        self.setFont(QFont("Arial", 16))
+        self.setFont(_ArialFont(16))
 
         self._set_label()
 
@@ -125,7 +143,7 @@ class ProgressDialog(QtWidgets.QProgressDialog):
 class StatusBar(QtWidgets.QStatusBar):
     def __init__(self, font_size: int = 12) -> None:
         super().__init__()
-        self.setFont(QFont("Arial", font_size))
+        self.setFont(_ArialFont(font_size))
         self.setStyleSheet(f"color: gray;")
         self.setSizeGripEnabled(False)
 
@@ -138,10 +156,11 @@ class StatusBar(QtWidgets.QStatusBar):
 
 
 class FailMessageBox(QtWidgets.QMessageBox):
-    """The is a message box that shows an error (failed progress)."""
-    def __init__(self, fail_message: str, parent: QtWidgets.QWidget = None) -> None:
+    """The is a critical message box that shows an error (failed progress)."""
+    def __init__(self, fail_message: str,
+                 parent: QtWidgets.QWidget = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Fail")
         self.setIcon(QtWidgets.QMessageBox.Critical)
         self.setText(fail_message)
-        self.setFont(QFont("Arial", 12))
+        self.setFont(_ArialFont(12))

--- a/intergrated_gui/frame_widget.py
+++ b/intergrated_gui/frame_widget.py
@@ -4,7 +4,7 @@ from PyQt5.QtWidgets import QLabel, QWidget
 
 
 class FrameWidget(QLabel):
-    def __init__(self, parent: QWidget = None):
+    def __init__(self, parent: QWidget = None) -> None:
         super().__init__(parent)
         self.setStyleSheet("border: 1px solid black;")
 
@@ -20,11 +20,11 @@ class FrameWidget(QLabel):
             # to save efficiency
             return
         # This is a self-adjust way.
-        # If simply use self.frameGeometry().width(), the image will grow.
-        # Because the image is always as big as the widget and PyQt will always
-        # give use a bigger widget, unstoppable.
+        # NOTE: If simply use self.frameGeometry().width(), the image will grow.
+        #   Because the image is always as big as the widget and PyQt will
+        #   always give us a bigger widget, unstoppable.
         self.setPixmap(QPixmap.fromImage(frame).scaled(
-            self.frameGeometry().width() - 10,
+            self.frameGeometry().width()  - 10,
             self.frameGeometry().height() - 10,
             Qt.KeepAspectRatio
         ))

--- a/intergrated_gui/gui_state.ini
+++ b/intergrated_gui/gui_state.ini
@@ -3,6 +3,7 @@ checked = True
 camera_dist = 45
 warn_dist = 40
 warning_enabled = True
+file_path = C:/Users/user/Desktop/webcam-applications/img/ref_img.jpg
 
 [time]
 checked = True

--- a/intergrated_gui/gui_state.ini
+++ b/intergrated_gui/gui_state.ini
@@ -2,23 +2,23 @@
 checked = True
 camera_dist = 45
 warn_dist = 40
-warning_enabled = False
+warning_enabled = True
 
 [time]
 checked = True
 time_limit = 30
 break_time = 10
-warning_enabled = False
+warning_enabled = True
 
 [posture]
 checked = True
 warn_angle = strict
-model_path = default
-warning_enabled = False
+model_path = custom
+warning_enabled = True
 
 [brightness]
 checked = False
-slider_value = 0
+slider_value = 10
 webcam_enabled = True
-color_system_enabled = True
+color_system_enabled = False
 

--- a/intergrated_gui/information_widget.py
+++ b/intergrated_gui/information_widget.py
@@ -17,8 +17,8 @@ class TextColor(Enum):
 
 
 class InformationWidget(QWidget):
-    """This widget provides update method to show the result of applications
-    on its corresponding labels.
+    """Provides update methods to show the results of applications on
+    their corresponding labels.
     """
     def __init__(self, parent: QWidget = None) -> None:
         super().__init__(parent)
@@ -40,10 +40,10 @@ class InformationWidget(QWidget):
         """
         self.information["distance"].setNum(round(distance, 2))
 
+        color: TextColor = TextColor.BLACK
         if state is DistanceState.WARNING:
-            self.information["distance"].set_color(TextColor.RED.value)
-        else:
-            self.information["distance"].set_color(TextColor.BLACK.value)
+            color = TextColor.RED
+        self.information["distance"].set_color(color.value)
 
     @pyqtSlot(int, TimeState)
     def update_time(self, time: int, state: TimeState) -> None:
@@ -55,16 +55,15 @@ class InformationWidget(QWidget):
             time: Time to update, in seconds.
             state: The state of the time.
         """
-        time_str: str = f"{(time // 60):02d}:{(time % 60):02d}"
+        time_str = f"{(time // 60):02d}:{(time % 60):02d}"
         self.information["time"].setText(time_str)
         self.information["time-state"].setText(state.name.lower())
 
+        color: TextColor = TextColor.BLACK
         if state is TimeState.BREAK:
-            self.information["time"].set_color(TextColor.RED.value)
-            self.information["time-state"].set_color(TextColor.RED.value)
-        else:
-            self.information["time"].set_color(TextColor.BLACK.value)
-            self.information["time-state"].set_color(TextColor.BLACK.value)
+            color = TextColor.RED
+        self.information["time"].set_color(color.value)
+        self.information["time-state"].set_color(color.value)
 
     @pyqtSlot(PostureLabel, str)
     def update_posture(self, posture: PostureLabel, detail: str) -> None:
@@ -81,12 +80,11 @@ class InformationWidget(QWidget):
         wrapped_detail: str = detail.replace(":", ":\n")
         self.information["posture-detail"].setText(wrapped_detail)
 
+        color: TextColor = TextColor.BLACK
         if posture is PostureLabel.SLUMP:
-            self.information["posture"].set_color(TextColor.RED.value)
-            self.information["posture-detail"].set_color(TextColor.RED.value)
-        else:
-            self.information["posture"].set_color(TextColor.BLACK.value)
-            self.information["posture-detail"].set_color(TextColor.BLACK.value)
+            color = TextColor.RED
+        self.information["posture"].set_color(color.value)
+        self.information["posture-detail"].set_color(color.value)
 
     @pyqtSlot(int)
     def update_brightness(self, brightness: int) -> None:
@@ -121,7 +119,7 @@ class InformationWidget(QWidget):
 
         font_size: int = 15
         for name, description in information.items():
-            # Notice that if the line warp isn't set to True,
+            # Notice that if the line wrap isn't set to True,
             # the label might grow and affect size of other widget.
             self.information[name] = Label(font_size=font_size, wrap=True)
             self.information[name].setFrameStyle(QFrame.WinPanel | QFrame.Raised)

--- a/intergrated_gui/panel_controller.py
+++ b/intergrated_gui/panel_controller.py
@@ -1,5 +1,6 @@
 import os
 from configparser import ConfigParser
+from functools import partial
 
 from PyQt5.QtCore import QCoreApplication, QEvent, QObject, Qt, pyqtSlot
 from PyQt5.QtGui import QKeyEvent
@@ -192,11 +193,15 @@ class PanelController(QObject):
         warning.toggled.connect(lambda checked: self._app.set_focus_time(warning_enabled=checked))
 
     def _connect_posture_signals(self) -> None:
+        def change_tolerance_angle(checked: bool, angle: AngleTolerance) -> None:
+            if checked:
+                self._app.set_posture_detect(warn_angle=angle)
+
         panel = self._panel.panels["posture"]
 
         panel.toggled.connect(lambda checked: self._app.set_posture_detect(enabled=checked))
-        panel.angles[AngleTolerance.LOOSE].toggled.connect(lambda checked: self._app.set_posture_detect(warn_angle=AngleTolerance.LOOSE) if checked else None)
-        panel.angles[AngleTolerance.STRICT].toggled.connect(lambda checked: self._app.set_posture_detect(warn_angle=AngleTolerance.STRICT) if checked else None)
+        for angle in AngleTolerance:
+            panel.angles[angle].toggled.connect(partial(change_tolerance_angle, angle=angle))
         custom = panel.custom
         custom.toggled.connect(lambda checked: self._app.set_posture_detect(model_path=(ModelPath.CUSTOM if checked else ModelPath.DEFAULT)))
         warning = panel.warning

--- a/intergrated_gui/panel_controller.py
+++ b/intergrated_gui/panel_controller.py
@@ -88,8 +88,7 @@ class PanelController(QObject):
             config.set("distance", name, line_edit.text())
         config.set("distance", "warning_enabled",
             str(panels["distance"].warning.isChecked()))
-        config.set("distance", "file_path",
-            str(panels["distance"].file_path.text()))
+        config.set("distance", "file_path", panels["distance"].file_path.text())
         # time
         for name, line_edit in panels["time"].settings.items():
             config.set("time", name, line_edit.text())

--- a/intergrated_gui/panel_controller.py
+++ b/intergrated_gui/panel_controller.py
@@ -3,6 +3,7 @@ from configparser import ConfigParser
 
 from PyQt5.QtCore import QCoreApplication, QEvent, QObject, Qt, pyqtSlot
 from PyQt5.QtGui import QKeyEvent
+from PyQt5.QtWidgets import QFileDialog
 
 from app.webcam_application_ import WebcamApplication
 from brightness.calcuator import BrightnessMode
@@ -165,12 +166,18 @@ class PanelController(QObject):
     def _connect_distance_signals(self) -> None:
         panel = self._panel.panels["distance"]
         panel.toggled.connect(lambda checked: self._app.set_distance_measure(enabled=checked))
+        panel.file_open.clicked.connect(self._choose_file_path)
         distance = panel.settings["camera_dist"]
         distance.editingFinished.connect(lambda: self._app.set_distance_measure(camera_dist=float(distance.text())))
         bound = panel.settings["warn_dist"]
         bound.editingFinished.connect(lambda: self._app.set_distance_measure(warn_dist=float(bound.text())))
         warning = panel.warning
         warning.toggled.connect(lambda checked: self._app.set_distance_measure(warning_enabled=checked))
+
+    def _choose_file_path(self) -> None:
+        filename, *_ =  QFileDialog.getOpenFileName(
+            self._panel.panels["distance"], "Open File", "C:\\", "Images (*.png *.jpg)")
+        self._panel.panels["distance"].img_path.setText(os.path.basename(filename))
 
     def _connect_time_signals(self) -> None:
         panel = self._panel.panels["time"]

--- a/intergrated_gui/panel_controller.py
+++ b/intergrated_gui/panel_controller.py
@@ -166,7 +166,7 @@ class PanelController(QObject):
     def _connect_distance_signals(self) -> None:
         panel = self._panel.panels["distance"]
         panel.toggled.connect(lambda checked: self._app.set_distance_measure(enabled=checked))
-        panel.file_open.clicked.connect(self._choose_file_path)
+        panel.file_open.clicked.connect(lambda: self._app.set_distance_measure(ref_img_path=self._choose_file_path()))
         distance = panel.settings["camera_dist"]
         distance.editingFinished.connect(lambda: self._app.set_distance_measure(camera_dist=float(distance.text())))
         bound = panel.settings["warn_dist"]
@@ -174,11 +174,11 @@ class PanelController(QObject):
         warning = panel.warning
         warning.toggled.connect(lambda checked: self._app.set_distance_measure(warning_enabled=checked))
 
-    def _choose_file_path(self) -> None:
+    def _choose_file_path(self) -> str:
         filename, *_ =  QFileDialog.getOpenFileName(
             self._panel.panels["distance"], "Open File", "C:\\", "Images (*.png *.jpg)")
         self._panel.panels["distance"].file_path.setText(os.path.basename(filename))
-        self._app.set_ref_image_path(filename, float(self._panel.panels["distance"].settings["camera_dist"].text()))
+        return filename
 
     def _connect_time_signals(self) -> None:
         panel = self._panel.panels["time"]

--- a/intergrated_gui/panel_controller.py
+++ b/intergrated_gui/panel_controller.py
@@ -177,7 +177,8 @@ class PanelController(QObject):
     def _choose_file_path(self) -> None:
         filename, *_ =  QFileDialog.getOpenFileName(
             self._panel.panels["distance"], "Open File", "C:\\", "Images (*.png *.jpg)")
-        self._panel.panels["distance"].img_path.setText(os.path.basename(filename))
+        self._panel.panels["distance"].file_path.setText(os.path.basename(filename))
+        self._app.set_ref_image_path(filename, float(self._panel.panels["distance"].settings["camera_dist"].text()))
 
     def _connect_time_signals(self) -> None:
         panel = self._panel.panels["time"]

--- a/intergrated_gui/panel_widget.py
+++ b/intergrated_gui/panel_widget.py
@@ -14,7 +14,8 @@ from intergrated_gui.component import (
 
 
 class PanelWidget(QWidget):
-    def __init__(self, parent: QWidget= None) -> None:
+    """A widget which contains the views of applications."""
+    def __init__(self, parent: QWidget = None) -> None:
         super().__init__(parent)
 
         self.panels: Dict[str, CheckableGroupBox] = {
@@ -33,6 +34,7 @@ class PanelWidget(QWidget):
 
 
 class DistancePanel(CheckableGroupBox):
+    """A view which contains the settings of distance measurement."""
     def __init__(self, parent: QWidget = None) -> None:
         super().__init__("Distance Measurement", parent)
 
@@ -43,15 +45,18 @@ class DistancePanel(CheckableGroupBox):
         self._set_restrictions()
 
     def _create_settings(self) -> None:
+        # the file path line and button are in their own layout
         self._file_path_layout = QHBoxLayout()
-        self._layout.setLayout(0, QFormLayout.SpanningRole, self._file_path_layout)
-
         self._file_path_layout.addWidget(Label("Reference:"))
-        self.img_path = LineEdit()
-        self.img_path.setReadOnly(True)
-        self._file_path_layout.addWidget(self.img_path)
+
+        self.file_path = LineEdit()
+        self.file_path.setReadOnly(True)
+        self._file_path_layout.addWidget(self.file_path)
+
         self.file_open = ActionButton("Open File...")
         self._file_path_layout.addWidget(self.file_open)
+
+        self._layout.setLayout(0, QFormLayout.SpanningRole, self._file_path_layout)
 
         settings = {
             "camera_dist": "Distance in reference:",
@@ -81,6 +86,7 @@ class DistancePanel(CheckableGroupBox):
 
 
 class TimePanel(CheckableGroupBox):
+    """A view which contains the settings of focus timing."""
     def __init__(self, parent: QWidget = None) -> None:
         super().__init__("Focus Timing", parent)
 
@@ -126,6 +132,7 @@ class AngleTolerance(IntEnum):
     STRICT = 15
 
 class PosturePanel(CheckableGroupBox):
+    """A view which contains the settings of posture detection."""
     def __init__(self, parent: QWidget = None) -> None:
         super().__init__("Posture Detection", parent)
 
@@ -140,15 +147,13 @@ class PosturePanel(CheckableGroupBox):
         group_box.setLayout(box_layout)
         self._layout.addWidget(group_box)
 
-        angles = [AngleTolerance.LOOSE, AngleTolerance.STRICT]
         self.angles: Dict[AngleTolerance, OptionRadioButton] = {}
-        for tolerance in angles:
-            self.angles[tolerance] = OptionRadioButton(f"{tolerance.name.lower()} ({tolerance})")
+        for tolerance in AngleTolerance:
+            btn = OptionRadioButton(f"{tolerance.name.lower()} ({tolerance})")
+            self.angles[tolerance] = btn
+            box_layout.addWidget(btn)
         # a loose angle tolerance is used in default
         self.angles[AngleTolerance.LOOSE].setChecked(True)
-
-        for btn in self.angles.values():
-            box_layout.addWidget(btn)
 
         # sound warning is enabled in default
         self.warning = OptionCheckBox("enable sound warning")
@@ -160,6 +165,7 @@ class PosturePanel(CheckableGroupBox):
 
 
 class BrightnessPanel(CheckableGroupBox):
+    """A view which contains which the settings of brightness optimization."""
     def __init__(self, parent: QWidget = None) -> None:
         super().__init__("Brightness Optimization", parent)
 
@@ -175,8 +181,9 @@ class BrightnessPanel(CheckableGroupBox):
 
     def _create_modes(self) -> None:
         # name | description
-        modes = {
-            BrightnessMode.WEBCAM: "Webcam-based brightness detector \n(webcam required)",
+        modes: Dict[BrightnessMode, str] = {
+            BrightnessMode.WEBCAM: ("Webcam-based brightness detector \n"
+                                    "(webcam required)"),
             BrightnessMode.COLOR_SYSTEM: "Color-system mode",
         }
         self.modes: Dict[BrightnessMode, OptionCheckBox] = {}

--- a/intergrated_gui/panel_widget.py
+++ b/intergrated_gui/panel_widget.py
@@ -2,11 +2,15 @@ from enum import IntEnum
 from typing import Dict
 
 from PyQt5.QtGui import QDoubleValidator, QIntValidator
-from PyQt5.QtWidgets import QFormLayout, QGridLayout, QGroupBox, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import (
+    QFormLayout, QGridLayout, QGroupBox, QHBoxLayout, QVBoxLayout, QWidget,
+)
 
 from brightness.calcuator import BrightnessMode
-from intergrated_gui.component import (CheckableGroupBox, HorizontalSlider, Label,
-                                       LineEdit, OptionCheckBox, OptionRadioButton)
+from intergrated_gui.component import (
+    ActionButton, CheckableGroupBox, HorizontalSlider, Label, LineEdit,
+    OptionCheckBox, OptionRadioButton,
+)
 
 
 class PanelWidget(QWidget):
@@ -39,6 +43,16 @@ class DistancePanel(CheckableGroupBox):
         self._set_restrictions()
 
     def _create_settings(self) -> None:
+        self._file_path_layout = QHBoxLayout()
+        self._layout.setLayout(0, QFormLayout.SpanningRole, self._file_path_layout)
+
+        self._file_path_layout.addWidget(Label("Reference:"))
+        self.img_path = LineEdit()
+        self.img_path.setReadOnly(True)
+        self._file_path_layout.addWidget(self.img_path)
+        self.file_open = ActionButton("Open File...")
+        self._file_path_layout.addWidget(self.file_open)
+
         settings = {
             "camera_dist": "Distance in reference:",
             "warn_dist": "Shortest distance allowed:",


### PR DESCRIPTION
## What's the problem?

Users could only put the reference image required by *distance measurement* in the *img* folder.

## What's better?

Users can now specify the path where the file is put anytime,
and the configuration will remember the path.

Resolves: #9 