### PR TITLE
Make `server` a module

### DIFF
--- a/server/gui/component.py
+++ b/server/gui/component.py
@@ -18,6 +18,7 @@ class ActionButton(QtWidgets.QPushButton):
         super().__init__(text)
         self.setFont(_ArialFont(font_size))
 
+
 class PullDownMenu(QtWidgets.QComboBox):
     def __init__(self, font_size: int = 16) -> None:
         super().__init__()
@@ -26,6 +27,7 @@ class PullDownMenu(QtWidgets.QComboBox):
 
     def add_item(self, item: str) -> None:
         self.addItem(item)
+
 
 class Label(QtWidgets.QLabel):
     def __init__(self, text: str = "",
@@ -37,6 +39,7 @@ class Label(QtWidgets.QLabel):
     def set_color(self, color: str) -> None:
         """Sets the text color of the label."""
         self.setStyleSheet(f"color: {color};")
+
 
 class LineEdit(QtWidgets.QLineEdit):
     """Placeholder text is easily set with constructor.

--- a/server/gui/window.py
+++ b/server/gui/window.py
@@ -1,7 +1,7 @@
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QMainWindow, QVBoxLayout, QWidget
 
-from gui.component import Label, LineEdit, PullDownMenu
+from server.gui.component import Label
 
 
 class FlaskGui(QMainWindow):
@@ -17,7 +17,7 @@ class FlaskGui(QMainWindow):
         self.setCentralWidget(self._central_widget)
 
         self._create_label()
-    
+
     def _create_label(self):
         self.label = Label("No grade received.", wrap=True)
         self._general_layout.addWidget(self.label, alignment=Qt.AlignCenter)

--- a/server/main.py
+++ b/server/main.py
@@ -4,8 +4,8 @@ from threading import Thread
 from PyQt5.QtWidgets import QApplication
 from flask import Flask, request
 
-from gui.controller import GuiController
-from gui.window import FlaskGui
+from server.gui.controller import GuiController
+from server.gui.window import FlaskGui
 
 
 # Create flask instance.

--- a/server/post.py
+++ b/server/post.py
@@ -3,6 +3,8 @@ import time
 
 import requests
 
+from util.path import to_abs_path
+
 
 def post_grade(data):
     for grade in data["grades"]:
@@ -11,7 +13,7 @@ def post_grade(data):
 
 
 def main():
-    with open("grade.json") as f:
+    with open(to_abs_path("server/grade.json")) as f:
         data = json.load(f)
     # posting is outside of "with" to have the file closed as early
     # as possible


### PR DESCRIPTION
# What's the problem?

We've already have a *gui/* folder, and now by adding another *gui/* under *server/*,
*mypy check* is confused since it doesn't know which *gui* we mean when seeing `import gui`.

# What's better?

So now let's make `server` a module and always use **absolute import path**.
Then the import of *server/gui* will be `import server.gui`, which explicitly tells the intention.

## BREAKING CHANGE
Run *server/main.py* by `python -m server.main` under the main *webcam-applications/*
directory instead of `python server/main.py` or `cd` into *server/* and `python main.py`.
*server/post.py* is the same, too.
The way to run a module as a script is special.