### PR TITLE
Add expand/collapsible section to display grade records

### DIFF
--- a/teacher/monitor.py
+++ b/teacher/monitor.py
@@ -92,7 +92,7 @@ class ColumnHeader:
 
 
 class Monitor(QMainWindow):
-    s_button_clicked = pyqtSignal(int)
+    s_button_clicked = pyqtSignal(str)
 
     def __init__(self, header: ColumnHeader, key_label: str = None) -> None:
         super().__init__()
@@ -118,17 +118,20 @@ class Monitor(QMainWindow):
 
     def insert_row(self, row: Row) -> None:
         """Inserts a new row to the bottom of the table."""
-        self._table.addTopLevelItem(QTreeWidgetItem())
+        new_item = QTreeWidgetItem()
+        self._table.addTopLevelItem(new_item)
         self.update_row(self._table.topLevelItemCount() - 1, row)
 
-        # button = QPushButton("look back")
-        # key_index = self._header.labels().index(self._key_label)
-        # # send id to controller
-        # button.clicked.connect(
-        #     lambda: self.s_button_clicked.emit(row[key_index].value)
-        # )
-        # # append button in row
-        # self._table.setCellWidget(row_no, len(row), button)
+        button = QPushButton("look back")
+        key_index = self._header.labels().index(self._key_label)
+        # send key value to controller
+        # Since the signal carries a "str" regardless of the type of key value,
+        # always convert to str to prevent type error or surprisingly result.
+        button.clicked.connect(
+            lambda: self.s_button_clicked.emit(str(row[key_index].value))
+        )
+        # append button in row
+        self._table.setItemWidget(new_item, len(row), button)
 
     def update_row(self, row_no: int, row: Row) -> None:
         item = self._table.topLevelItem(row_no)


### PR DESCRIPTION
## What's new?

`QTreeWidget` is used instead of `QTableWidget` because it has built-in expand/collapse methods.
- *QTreeWidget* has each of if its rows handled by `QTreeWidgetItem`
- by adding a *QTreeWidgetItem* as another's *child*, it'll be collapsed and hidden until *expand button* is clicked
- *history* button is removed

I didn't work with *database* in this PR; the old grade is directly added as a child when a new grade comes.

<img src="https://user-images.githubusercontent.com/52515370/163700743-d85b3d20-1123-4fbc-b186-807ee553c390.png" alt="current view of monitor" width="410" height="233">

## TODOs
- fetch the current 5 old grades from the *database* and display them in the *expanded section* when the *expand button* is clicked
 