### PR TITLE
Show and plot history grades

### DIFF
--- a/teacher/controller.py
+++ b/teacher/controller.py
@@ -74,8 +74,11 @@ class MonitorController(QObject):
         self._monitor.s_item_clicked.connect(plot_history_if_grade_clicked)
         def show_history(student_id: str) -> None:
             row_no = self._monitor.search_row_no(("id", student_id))
+            id_index = self._monitor.col_header.labels().index("id")
             for row in self._get_history_from_database(student_id, Monitor.MAX_HISTORY_NUM):
                 hist_item = self._monitor.add_history_of_row(row_no, self._monitor.col_header.to_row(row))
+                # all ids are the same, duplicate, so omit that
+                hist_item.setText(id_index, "")
                 self._set_background_by_grade(hist_item, row["grade"])
         self._monitor.s_item_expanded.connect(show_history)
         self._monitor.s_item_collapsed.connect(

--- a/teacher/controller.py
+++ b/teacher/controller.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, List, Mapping
 
+import matplotlib.pyplot as plt
 import requests
 from PyQt5.QtCore import QObject, QTimer, Qt
 from PyQt5.QtGui import QBrush
@@ -59,7 +60,19 @@ class MonitorController(QObject):
             self._conn.execute(sql)
 
     def _connect_signal(self):
-        self._monitor.s_button_clicked.connect(lambda id: print(id))
+        def print_history_if_grade_clicked(student_id, label):
+            if label == "grade":
+                grade = []
+                time = []
+                for row in self._get_history_from_database(student_id, 5):
+                    grade.append(row["grade"])
+                    time.append(row["time"].timestamp())
+                print(time)
+                ax = plt.subplot()
+                ax.stem(time, grade)
+                ax.set(ylim=(0, 1))
+                plt.show()
+        self._monitor.s_item_clicked.connect(print_history_if_grade_clicked)
 
     def _get_grades_from_server(self) -> None:
         """Get new grades from the server and

--- a/teacher/controller.py
+++ b/teacher/controller.py
@@ -2,7 +2,7 @@ import atexit
 import sqlite3
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, List, Mapping
 
 import requests
 from PyQt5.QtCore import QObject, QTimer, Qt
@@ -72,6 +72,11 @@ class MonitorController(QObject):
 
             self.store_new_grade(datum)
             self.show_new_grade(datum)
+
+    def _get_history_from_database(self, student_id: int, amount: int) -> List[sqlite3.Row]:
+        sql = f"SELECT * FROM {self._table_name} WHERE id={student_id} ORDER BY time LIMIT {amount};"
+        with self._conn:
+            return self._conn.execute(sql).fetchall()
 
     def store_new_grade(self, grade: Mapping[str, Any]) -> None:
         """Stores new grade into the database."""

--- a/teacher/controller.py
+++ b/teacher/controller.py
@@ -76,7 +76,9 @@ class MonitorController(QObject):
             row_no = self._monitor.search_row_no(("id", student_id))
             id_index = self._monitor.col_header.labels().index("id")
             for row in self._get_history_from_database(student_id, Monitor.MAX_HISTORY_NUM):
-                hist_item = self._monitor.add_history_of_row(row_no, self._monitor.col_header.to_row(row))
+                hist_item = self._monitor.add_history_of_row(
+                    row_no, self._monitor.col_header.to_row(row)  # type: ignore
+                )  # sqlite3.Row does support mapping
                 # all ids are the same, duplicate, so omit that
                 hist_item.setText(id_index, "")
                 self._set_background_by_grade(hist_item, row["grade"])

--- a/teacher/monitor.py
+++ b/teacher/monitor.py
@@ -220,9 +220,16 @@ class Monitor(QMainWindow):
         return -1
 
     def _connect_signals(self) -> None:
+        def get_parent_if_is_child(item: QTreeWidgetItem) -> QTreeWidgetItem:
+            # since the id of history is omitted, get parent to obtain the real id
+            if item.parent() is not None:
+                return item.parent()
+            return item
         self._table.itemClicked.connect(
             lambda item, col_no: self.s_item_clicked.emit(
-                *self._map_item_and_column_to_key_and_label(item, col_no)
+                *self._map_item_and_column_to_key_and_label(
+                    get_parent_if_is_child(item), col_no
+                )
             )
         )
         self._table.itemCollapsed.connect(

--- a/teacher/monitor.py
+++ b/teacher/monitor.py
@@ -92,7 +92,7 @@ class ColumnHeader:
 class Monitor(QMainWindow):
     s_button_clicked = pyqtSignal(str)
 
-    _MAX_HISTORY_NUM: int = 5
+    MAX_HISTORY_NUM: int = 5
 
     def __init__(self, header: ColumnHeader, key_label: str = None) -> None:
         super().__init__()
@@ -148,15 +148,15 @@ class Monitor(QMainWindow):
     def add_history_of_row(self, row_no: int, hist_row: Row) -> None:
         """Adds history from the top to the row specified with row number.
 
-        At most _MAX_HISTORY_NUM histories can be shown.
+        At most MAX_HISTORY_NUM histories can be shown.
         """
         item = self._table.topLevelItem(row_no)
         content = [str(col.value) for col in hist_row]
         # 0 is from top
         item.insertChild(0, QTreeWidgetItem(item, content))
 
-        while item.childCount() > Monitor._MAX_HISTORY_NUM:
-            item.removeChild(item.child(Monitor._MAX_HISTORY_NUM))
+        while item.childCount() > Monitor.MAX_HISTORY_NUM:
+            item.removeChild(item.child(Monitor.MAX_HISTORY_NUM))
         return item
 
     def sort_rows_by_label(self, label: str, order: Qt.SortOrder) -> None:

--- a/teacher/monitor.py
+++ b/teacher/monitor.py
@@ -2,6 +2,7 @@ from typing import Any, Iterable, List, Mapping, Tuple, TypeVar
 
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QMainWindow, QTreeWidget, QTreeWidgetItem
+from more_itertools import SequenceView
 
 
 T = TypeVar("T")
@@ -57,6 +58,10 @@ class ColumnHeader:
             ("id", int), ("name", str), ("class no.", int)
         """
         self._headers = tuple(headers)
+        # store separatly so we don't iterate them again and again when getters
+        # are called, which is more efficient
+        self._labels = tuple(label for label, _ in self._headers)
+        self._types = tuple(value_type for _, value_type in self._headers)
 
     @property
     def col_count(self) -> int:
@@ -65,11 +70,11 @@ class ColumnHeader:
 
     def labels(self) -> Tuple[str, ...]:
         """Returns the labels of the header in column order."""
-        return tuple(label for label, _ in self._headers)
+        return self._labels
 
     def types(self) -> Tuple[type, ...]:
         """Returns the corresponding value type of the labels in column order."""
-        return tuple(value_type for _, value_type in self._headers)
+        return self._types
 
     def to_row(self, values: Mapping[str, Any]) -> Row:
         """Packs the values into the desirable Row form.

--- a/teacher/monitor.py
+++ b/teacher/monitor.py
@@ -176,7 +176,7 @@ class Monitor(QMainWindow):
         Notice that all values are with type: str, not their original types.
         """
         item = self._table.topLevelItem(row_no)
-        row = []
+        row = RowContent()
         for i in range(item.columnCount()):
             row.append(Col(i, self._header.labels()[i], item.text(i)))
         return row

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -1,6 +1,6 @@
 import unittest
 
-from teacher.monitor import Col, ColumnHeader, Row
+from teacher.monitor import Col, ColumnHeader, RowContent
 
 
 class ColTestCase(unittest.TestCase):
@@ -36,7 +36,7 @@ class ColumnHeaderTestCase(unittest.TestCase):
             Col(1, "budget", 100_000),
             Col(2, "list", ["shoes", ["computer", "headphone"]]),
         ]
-        row: Row = self.col_header.to_row(data)
+        row: RowContent = self.col_header.to_row(data)
 
         self.assertTrue(len(row), len(expected_row))
         # we can't simply compare Cols with "==" since __eq__ isn't implemented
@@ -75,7 +75,7 @@ class ColumnHeaderTestCase(unittest.TestCase):
             Col(1, "budget", 100_000),
             Col(2, "list", ["shoes", ["computer", "headphone"]]),
         ]
-        row: Row = self.col_header.to_row(data)
+        row: RowContent = self.col_header.to_row(data)
 
         self.assertTrue(len(row), len(expected_row))
         for col, expected_col in zip(row, expected_row):

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -23,7 +23,7 @@ class ColumnHeaderTestCase(unittest.TestCase):
     def test_labels(self) -> None:
         """Get labels in order from the header."""
         labels = ("name", "budget", "list")
-        self.assertEqual(labels, self.col_header.labels())
+        self.assertEqual(labels, tuple(self.col_header.labels()))
 
     def test_to_row(self) -> None:
         data = {


### PR DESCRIPTION
## Show history grades

When the *expansion indicator* on the `Monitor` is clicked, the `MonitorController` gets history grades from the *database* and shows them up to the `Monitor`.
Those histories are then removed after the *expansion indicator* is again clicked for collapse.

## Plot history grades

When the column of label *grade* is clicked, regardless of it's a current grade or history, the `MonitorController` gets history grades from the *database* and makes a plot to illustrate the *concentration* flow of the user.

<img src="https://user-images.githubusercontent.com/52515370/164900458-9936c2b9-9bf4-4f84-8266-8fbd3ed4e3ba.png" alt="view of monitor and plot" width=510 height=414>

The plot is still immature and some of the codes are not clean, but this PR should be enough to direct our way.
