### PR TITLE
Remove `ModelLayer` from `PostureGuard` & Fix freeze on MTCNN

### DIFF
--- a/posture/calculator.py
+++ b/posture/calculator.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 import cv2
-import numpy as np
 from nptyping import Int, NDArray
 
 from util.color import BGR, GREEN

--- a/posture/calculator.py
+++ b/posture/calculator.py
@@ -1,14 +1,12 @@
-import numpy as np
 import math
 import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import cv2
-import tensorflow as tf
-from nptyping import Float, Int, NDArray
-from tensorflow.keras import models
+import numpy as np
+from nptyping import Int, NDArray
 
 from util.color import BGR, GREEN
 from util.image_type import ColorImage
@@ -143,20 +141,3 @@ def draw_landmarks_used_by_angle_calculator(
     # make lines transparent
     canvas_ = cv2.addWeighted(canvas_, 0.4, canvas, 0.6, 0)
     return canvas_
-
-
-class PosturePredictor:
-    def __init__(self, model: models.Sequential) -> None:
-        self._model = model
-
-    def predict(self, frame: ColorImage) -> Tuple[PostureLabel, Float[32]]:
-        """Returns the posture label and confidence of this predict.
-
-        Arguments:
-            frame: The image contains posture to be predicted.
-        """
-        frame_exp = tf.expand_dims(cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY), 0)
-        predictions = self._model(frame_exp)
-        score = tf.nn.softmax(predictions[0])
-
-        return PostureLabel(np.argmax(score)), np.max(score)

--- a/posture/guard.py
+++ b/posture/guard.py
@@ -1,6 +1,3 @@
-# The 3-layer posture detection refers to
-# https://github.com/EE-Ind-Stud-Group/posture-detection
-
 from typing import Optional, Tuple
 
 import cv2
@@ -8,8 +5,8 @@ import mtcnn
 from nptyping import Int, NDArray
 
 from concentration.grader import ConcentrationGrader
-from posture.calculator import PostureLabel, PosturePredictor
-from posture.layer import AngleLayer, DetectionLayer, HogLayer, ModelLayer, MtcnnLayer
+from posture.calculator import PostureLabel
+from posture.layer import AngleLayer, DetectionLayer, HogLayer, MtcnnLayer
 from sounds.sound_guard import SoundRepeatGuard
 from util.image_type import ColorImage
 from util.path import to_abs_path
@@ -21,14 +18,11 @@ class PostureGuard(SoundRepeatGuard):
     """
     def __init__(
             self,
-            predictor: PosturePredictor,
             warn_angle: float,
             warning_enabled: bool = True,
             grader: Optional[ConcentrationGrader] = None) -> None:
         """
         Arguments:
-            predictor:
-                Used to predict the label of image when a clear face isn't found.
             warn_angle:
                 Face slope angle larger than this is considered to be a slump posture.
             warning_enabled:
@@ -45,16 +39,8 @@ class PostureGuard(SoundRepeatGuard):
         )
         self._hog_layer = HogLayer(warn_angle)
         self._mtcnn_layer = MtcnnLayer(warn_angle)
-        self._model_layer = ModelLayer(predictor)
         self._mtcnn_detector = mtcnn.MTCNN()
         self._grader: Optional[ConcentrationGrader] = grader
-
-    def set_predictor(self, predictor: PosturePredictor) -> None:
-        """
-        Arguments:
-            predictor: Used to predict the label of image when a clear face isn't found.
-        """
-        self._model_layer.set_predictor(predictor)
 
     def set_warn_angle(self, warn_angle: float) -> None:
         """
@@ -68,7 +54,12 @@ class PostureGuard(SoundRepeatGuard):
             self,
             frame: ColorImage,
             landmarks: NDArray[(68, 2), Int[32]]) -> Tuple[PostureLabel, str]:
-        """Sound plays when is a "slump" posture if warning is enabled.
+        """Good or slump is determined by the angle of face; if there isn't a
+        face, the posture is always slump.
+
+        If warning is enabled, sound plays when is a slump posture.
+        An exception is that a slump under no face will never trigger sound warning
+        since it's not really because of a slump posture but the absence of user.
 
         Arguments:
             frame: The image contains posture to be predicted.
@@ -76,19 +67,18 @@ class PostureGuard(SoundRepeatGuard):
 
         Returns:
             The PostureLabel and the detail string of the determination.
-            None if any of the necessary attributes aren't set.
         """
-        # The posture detection used is made up of 3 layers, which are
-        # HOG (Dlib), MTCNN and self-trained model (TensorFlow).
+        # The posture detection used is made up of 2 layers,
+        # which are HOG (Dlib) and MTCNN.
         # HOG is accurate enough and has the fastest speed but needs front faces,
         # so it's used as the first layer; then when the angle is too large that
         # HOG fails, MTCNN takes over. It's robust but so slow that we can't have
         # it as the first layer; last, when the above 2 detections both fail on
-        # face detection, we use our model.
+        # face detection, we said that the user isn't concentrating since he/she
+        # isn't even in front of the screen.
 
-        layer: DetectionLayer
+        layer: AngleLayer
         if landmarks.any():
-            # layer 1
             self._hog_layer.detect(landmarks)
             layer = self._hog_layer
         else:
@@ -96,24 +86,21 @@ class PostureGuard(SoundRepeatGuard):
                 cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
             )
             if faces:
-                # layer 2
                 self._mtcnn_layer.detect(faces[0])
                 layer = self._mtcnn_layer
-            else:
-                # layer 3
-                self._model_layer.detect(frame)
-                layer = self._model_layer
+            else:  # no face
+                # a sufficienly large angle to be send as distraction
+                self._send_concentration_info(100)
+                # No face won't trigger sound warning since it's usually because
+                # of the user not in front of the screen, not really because of
+                # a slump posture.
+                return PostureLabel.SLUMP, "no face"
 
-        angle: float
-        if isinstance(layer, AngleLayer) and self._grader is not None:
+        if self._grader is not None:
             self._grader.add_face_center(layer.center)
-            angle = layer.angle
-        else:  # is model layer
-            # XXX: this is a hack to have all layers produce an angle
-            angle = 5 if layer.posture is PostureLabel.GOOD else 100
 
         self._repeat_sound_if(layer.posture is not PostureLabel.GOOD)
-        self._send_concentration_info(angle)
+        self._send_concentration_info(layer.angle)
 
         return layer.posture, layer.detail
 
@@ -129,6 +116,9 @@ class PostureGuard(SoundRepeatGuard):
         if self._grader is None:
             return
 
+        # this specific large value is chosen under the experiment of 5,194
+        # images labeled in good and 3,272 images labeled in slump;
+        # has 95% of the goods within -9.2 ~ 9.2
         TOO_LARGE = 9.2
         if abs(angle) > TOO_LARGE:
             self._grader.add_body_distraction()

--- a/posture/guard.py
+++ b/posture/guard.py
@@ -6,7 +6,7 @@ from nptyping import Int, NDArray
 
 from concentration.grader import ConcentrationGrader
 from posture.calculator import PostureLabel
-from posture.layer import AngleLayer, DetectionLayer, HogLayer, MtcnnLayer
+from posture.layer import AngleLayer, HogLayer, MtcnnLayer
 from sounds.sound_guard import SoundRepeatGuard
 from util.image_type import ColorImage
 from util.path import to_abs_path

--- a/posture/guard.py
+++ b/posture/guard.py
@@ -74,7 +74,7 @@ class PostureGuard(SoundRepeatGuard):
         # so it's used as the first layer; then when the angle is too large that
         # HOG fails, MTCNN takes over. It's robust but so slow that we can't have
         # it as the first layer; last, when the above 2 detections both fail on
-        # face detection, we said that the user isn't concentrating since he/she
+        # face detection, we say that the user isn't concentrating since he/she
         # isn't even in front of the screen.
 
         layer: AngleLayer
@@ -89,7 +89,7 @@ class PostureGuard(SoundRepeatGuard):
                 self._mtcnn_layer.detect(faces[0])
                 layer = self._mtcnn_layer
             else:  # no face
-                # a sufficienly large angle to be send as distraction
+                # a sufficienly large angle to be sent as distraction
                 self._send_concentration_info(100)
                 # No face won't trigger sound warning since it's usually because
                 # of the user not in front of the screen, not really because of

--- a/posture/layer.py
+++ b/posture/layer.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional, Tuple, cast
 
-from nptyping import Float, Int, NDArray
+from nptyping import Int, NDArray
 
 from posture.calculator import (
-    HogAngleCalculator, MtcnnAngleCalculator, PostureLabel, PosturePredictor
+    HogAngleCalculator, MtcnnAngleCalculator, PostureLabel
 )
 from util.image_type import ColorImage
 
@@ -42,6 +42,7 @@ class DetectionLayer(ABC):
 
 
 class AngleLayer(DetectionLayer):
+    """A layer that detects face to get angle and center of face.""" 
     def __init__(self, warn_angle: float) -> None:
         self._warn_angle = warn_angle
         self._angle: Optional[float] = None
@@ -105,26 +106,3 @@ class MtcnnLayer(AngleLayer):
         if len(center) != 2:
             raise ValueError("face points should be 2-dimensional")
         self._center = cast(Tuple[float, float], center)
-
-
-class ModelLayer(DetectionLayer):
-    def __init__(self, predictor: PosturePredictor) -> None:
-        super().__init__()
-        self._predictor: PosturePredictor = predictor
-        self._mtcnn_angle_calculator = MtcnnAngleCalculator()
-
-    def set_predictor(self, predictor: PosturePredictor) -> None:
-        """
-        Arguments:
-            predictor: Used to predict the label of image.
-        """
-        self._predictor = predictor
-
-    def detect(self, frame: ColorImage) -> None:
-        """
-        Arguments:
-            frame: The image contains posture to be detected.
-        """
-        conf: Float[32]
-        self._posture, conf = self._predictor.predict(frame)
-        self._detail = f"by model: {conf:.0%}"

--- a/posture/layer.py
+++ b/posture/layer.py
@@ -6,7 +6,6 @@ from nptyping import Int, NDArray
 from posture.calculator import (
     HogAngleCalculator, MtcnnAngleCalculator, PostureLabel
 )
-from util.image_type import ColorImage
 
 
 class DetectionLayer(ABC):
@@ -42,7 +41,7 @@ class DetectionLayer(ABC):
 
 
 class AngleLayer(DetectionLayer):
-    """A layer that detects face to get angle and center of face.""" 
+    """A layer that detects face to get angle and center of face."""
     def __init__(self, warn_angle: float) -> None:
         self._warn_angle = warn_angle
         self._angle: Optional[float] = None


### PR DESCRIPTION
## Remove *ModelLayer* from *PostureGuard*

The self-trained model used in the `ModelLayer` is not accurate enough and usually misleading.
So it's removed. Now only 2 layers remaining: *HOG* and *MTCNN*.
And a posture detection on *no face* always returns *SLUMP* without triggering the sound warning
because it's not really a slump posture but the absence of user.
This removal  also gives us the ability to differentiate a *normal slump* from an *absence slump*.

## Fix freeze on *MTCNN*

We use `TaskWorker`s to run applications but enter the next main while loop without waiting for any of them.
So if the task takes too much time, it will be aborted (deleted) by the next loop.
*MTCNN* takes more time than a non-waiting loop, so it's always aborted and seems like doing nothing.
To fix this, I use a `Barrier` to have the main loop wait for the tasks.